### PR TITLE
Module upgrades and Rocky 9 build fixes

### DIFF
--- a/EthercatMCExApp/src/Makefile
+++ b/EthercatMCExApp/src/Makefile
@@ -75,6 +75,9 @@ EthercatMC_LIBS += ads
 EthercatMC_DBD  += ads.dbd
 endif
 
+ifeq ($(USE_TIRPC),YES)
+EthercatMC_SYS_LIBS += tirpc
+endif
 
 EthercatMC_LIBS += EthercatMcSupport
 EthercatMC_LIBS += $(EPICS_BASE_IOC_LIBS)

--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+R2.1.0-0.1.3    2024-11-22 Jeremy Lorelli
+	Update to motor/R6.9-ess-0.0.2, asyn/R4.35-0.0.2, seq/R2.2.4-1.2, sscan/R2.10.2-1.1.0
+	Changes to support building for rocky9
+
 R2.1.0-0.1.1	2019-09-23 Bruce Hill
 	Update to calc/R3.7-1.0.1
 

--- a/configure/CONFIG_SITE.Common.rhel8-x86_64
+++ b/configure/CONFIG_SITE.Common.rhel8-x86_64
@@ -1,0 +1,1 @@
+USE_TIRPC=YES

--- a/configure/CONFIG_SITE.Common.rhel9-x86_64
+++ b/configure/CONFIG_SITE.Common.rhel9-x86_64
@@ -1,0 +1,1 @@
+USE_TIRPC=YES

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -19,11 +19,11 @@
 # Don't set your version to anything such as "test" that
 # could match a directory name.
 # ==========================================================
-ASYN_MODULE_VERSION	= R4.35-0.0.1
+ASYN_MODULE_VERSION	= R4.35-0.0.2
 CALC_MODULE_VERSION	= R3.7-1.0.1
-MOTOR_MODULE_VERSION	= R6.9-ess-0.0.1
-SSCAN_MODULE_VERSION	= R2.10.2-1.0.0
-SEQ_MODULE_VERSION	= R2.2.4-1.1
+MOTOR_MODULE_VERSION	= R6.9-ess-0.0.2
+SSCAN_MODULE_VERSION	= R2.10.2-1.1.0
+SEQ_MODULE_VERSION	= R2.2.4-1.2
 
 # ==========================================================
 # External Support module path definitions


### PR DESCRIPTION
* Fix linker errors in EthercatMC test IOC by linking against tirpc
* Upgrade numerous module versions